### PR TITLE
fix sort index bug

### DIFF
--- a/app/assets/javascripts/activeadmin-sortable.js
+++ b/app/assets/javascripts/activeadmin-sortable.js
@@ -11,7 +11,7 @@
         $.ajax({
           url: url,
           type: 'post',
-          data: { position: ui.item.index() + 1 },
+          data: { position: ui.item.index() },
           success: function() { window.location.reload() }
         });
       }


### PR DESCRIPTION
always drop position + 1 (mac + rails 4.2.0 + ruby 2.2.0 + safari & chrome)