### PR TITLE
Fix off-by-one sorting issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This extension assumes that you're using one of the following on any model you w
 
 ```ruby
 class Page < ActiveRecord::Base
-  acts_as_list
+  acts_as_list :position, top_of_list: 0
 end
 ```
 

--- a/app/assets/javascripts/activeadmin-sortable.js
+++ b/app/assets/javascripts/activeadmin-sortable.js
@@ -11,7 +11,7 @@
         $.ajax({
           url: url,
           type: 'post',
-          data: { position: ui.item.index() + 1 },
+          data: { position: ui.item.index() },
           success: function() { window.location.reload() }
         });
       }


### PR DESCRIPTION
This pull request fixes off-by-one sorting issue.

First issue: fix javascript off-by-one by remove "+1" from position.

Second: update README.md to show how to enable acts_as_list right by adding field for sort `:position` and default `top_of_list: 0` value.

Tested with activeadmin/activeadmin@893b46c6530cae30e30a5dd07b94f8a212a9804a
